### PR TITLE
ability to always compile (for development)

### DIFF
--- a/lib/assets-compiler.js
+++ b/lib/assets-compiler.js
@@ -27,7 +27,7 @@ var AssetsCompiler = module.exports = function AssetsCompiler(compound) {
 }
 
 AssetsCompiler.prototype.init = function() {
-  /** 
+  /**
    * Decide which asset directories to watch and which should
    * be precompiled
    */
@@ -65,7 +65,7 @@ AssetsCompiler.prototype.require = function(module) {
 
 /**
  * Precompiles assets in /app/assets/coffeescripts and /app/assets/stylesheets
- * 
+ *
  * @param {Array} List of asset types that should be precompiled
  */
 AssetsCompiler.prototype.precompileAssets = function(sourceExtensions) {
@@ -196,6 +196,10 @@ AssetsCompiler.prototype.compileAsset = function(sourcePath, destPath, compiler,
     doCompile = true;
   }
 
+  // special case: always compile
+  if (self.app.enabled('force assets compilation'))
+    doCompile = true;
+
   // make sure that the destination path exists
   // actually compile
   if (doCompile) {
@@ -223,7 +227,7 @@ AssetsCompiler.prototype.compilers = {};
 
 /**
 * Adds a new compiler.
-* @param {String||[String,...]} extensions: string or array of strings that represent 
+* @param {String||[String,...]} extensions: string or array of strings that represent
 *   the extensions this compiler handles
 * @param {Object} options: should contain a render function, and any other options for the compiler
 */


### PR DESCRIPTION
I ran into the following issue: When using sass or stylus, you will need to use @import to import external files. The main application.styl will not be compiled if you only change a file that is included there.

So this will take care of the 'force assets compilation' setting in compound so that assets are always compiled on every request.
